### PR TITLE
change: remove title attribute

### DIFF
--- a/src/HeatMap/HeatMap.js
+++ b/src/HeatMap/HeatMap.js
@@ -57,7 +57,6 @@ class HeatMap extends Component {
                 textAlign: 'center',
                 ...cellStyle(background, value, min, max, data, xi, yi)
               };
-              const title = (value || value === 0) && `${value} ${unit}`;
               return (
                 <Cell
                   key={`${xi}_${yi}`}
@@ -65,7 +64,6 @@ class HeatMap extends Component {
                   y={yi}
                   value={value}
                   onClick={onClick ? () => onClick(xi, yi) : undefined}
-                  title={title}
                   style={style}
                   height={height}
                 >


### PR DESCRIPTION
On hovering over a cell the default tool tip always shows, even if you don't want it. This PR just makes it so it isn't there by default and you can easily put it there if you want to.